### PR TITLE
Update Dockerfile

### DIFF
--- a/v0.7/english/Dockerfile
+++ b/v0.7/english/Dockerfile
@@ -1,10 +1,6 @@
-FROM debian:squeeze
+FROM java:openjdk-6-jre
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
-
-RUN apt-get update && apt-get install -y \
-    curl \
-    openjdk-6-jre
 
 ENV RELEASE_SERVER    spotlight.sztaki.hu
 ENV RELEASE_FILENAME  dbpedia-spotlight-latest.jar


### PR DESCRIPTION
apt-get install openjdk-6-jre fails with an error.  can we just use java:openjdk-6-jre.  curl pkg is already installed on the container.  This also reduces build time and layers on the docker image
