### PR TITLE
Switch to Alpine base image

### DIFF
--- a/nightly-build/danish/Dockerfile
+++ b/nightly-build/danish/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    da.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/da/model//$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/dutch/Dockerfile
+++ b/nightly-build/dutch/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    nl.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/nl/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/english/Dockerfile
+++ b/nightly-build/english/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    en_2+2.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/en/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/french/Dockerfile
+++ b/nightly-build/french/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    fr.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/fr/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/german/Dockerfile
+++ b/nightly-build/german/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    de.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/de/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/hungarian/Dockerfile
+++ b/nightly-build/hungarian/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    hu.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/hu/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/italian/Dockerfile
+++ b/nightly-build/italian/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    it.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/it/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/portuguese/Dockerfile
+++ b/nightly-build/portuguese/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    pt.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/pt/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/russian/Dockerfile
+++ b/nightly-build/russian/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    ru.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/ru/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/spanish/Dockerfile
+++ b/nightly-build/spanish/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    es.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/es/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/swedish/Dockerfile
+++ b/nightly-build/swedish/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    sv.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/sv/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/nightly-build/turkish/Dockerfile
+++ b/nightly-build/turkish/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-nightly-build.jar 
 ENV LANGUAGE_MODEL    tr.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/tr/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/danish/Dockerfile
+++ b/v0.7.1/danish/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    da.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/da/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/dutch/Dockerfile
+++ b/v0.7.1/dutch/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    nl.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/nl/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/english/Dockerfile
+++ b/v0.7.1/english/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    en_2+2.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/en/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/french/Dockerfile
+++ b/v0.7.1/french/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    fr.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/fr/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/german/Dockerfile
+++ b/v0.7.1/german/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    de.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/de/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/hungarian/Dockerfile
+++ b/v0.7.1/hungarian/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    hu.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/hu/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/italian/Dockerfile
+++ b/v0.7.1/italian/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    it.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/it/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/portuguese/Dockerfile
+++ b/v0.7.1/portuguese/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    pt.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/pt/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/russian/Dockerfile
+++ b/v0.7.1/russian/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    ru.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/ru/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/spanish/Dockerfile
+++ b/v0.7.1/spanish/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    es.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/es/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/swedish/Dockerfile
+++ b/v0.7.1/swedish/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    sv.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/sv/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7.1/turkish/Dockerfile
+++ b/v0.7.1/turkish/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.1.jar
 ENV LANGUAGE_MODEL    tr.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/tr/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/Dockerfile
+++ b/v0.7/Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:8-jre-alpine
+
+ENV RELEASE_SERVER=spotlight.sztaki.hu
+ENV VERSION=latest
+ENV MEMORY=2g
+ENV LANGUAGE_MODEL=${LANGUAGE}.tar.gz
+
+ADD http://${RELEASE_SERVER}/downloads/dbpedia-spotlight-${VERSION}.jar /
+
+ONBUILD RUN wget http://spotlight.sztaki.hu/downloads/latest_models/$LANGUAGE_MODEL /opt/spotlight \
+    && tar -xvf /$LANGUAGE_MODEL \
+    && rm -rf /$LANGUAGE_MODEL
+
+CMD java -Xmx${MEMORY} -jar /dbpedia-spotlight-${VERSION}.jar /${LANGUAGE} http://localhost:80/rest/
+
+EXPOSE 80

--- a/v0.7/danish/Dockerfile
+++ b/v0.7/danish/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    da.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/da/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/dutch/Dockerfile
+++ b/v0.7/dutch/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    nl.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/nl/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/english/Dockerfile
+++ b/v0.7/english/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    en_2+2.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/en/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/french/Dockerfile
+++ b/v0.7/french/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    fr.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/fr/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/german/Dockerfile
+++ b/v0.7/german/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    de.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/de/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/hungarian/Dockerfile
+++ b/v0.7/hungarian/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    hu.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/hu/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/italian/Dockerfile
+++ b/v0.7/italian/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    it.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/it/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/portuguese/Dockerfile
+++ b/v0.7/portuguese/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    pt.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/pt/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/russian/Dockerfile
+++ b/v0.7/russian/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    ru.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/ru/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/spanish/Dockerfile
+++ b/v0.7/spanish/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    es.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/es/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/swedish/Dockerfile
+++ b/v0.7/swedish/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    sv.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/sv/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v0.7/turkish/Dockerfile
+++ b/v0.7/turkish/Dockerfile
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-0.7.jar
 ENV LANGUAGE_MODEL    tr.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/tr/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/danish/Dockerfile
+++ b/v1.0/danish/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,13 +6,15 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    da.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
-    curl -O "http://$RELEASE_SERVER/2016-04/da/model//$LANGUAGE_MODEL" && \
+    curl -O "http://$RELEASE_SERVER/2016-04/da/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
-
+    rm  $LANGUAGE_MODEL && \
+    apk del curl && \
+    apk del curl
 
 ADD spotlight.sh /bin/spotlight.sh
 RUN chmod +x /bin/spotlight.sh

--- a/v1.0/dutch/Dockerfile
+++ b/v1.0/dutch/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    nl.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/nl/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/english/Dockerfile
+++ b/v1.0/english/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    en_2+2.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/en/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/french/Dockerfile
+++ b/v1.0/french/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    fr.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/fr/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/german/Dockerfile
+++ b/v1.0/german/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    de.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/de/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/hungarian/Dockerfile
+++ b/v1.0/hungarian/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    hu.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/hu/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/italian/Dockerfile
+++ b/v1.0/italian/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    it.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/it/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/portuguese/Dockerfile
+++ b/v1.0/portuguese/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    pt.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/pt/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/russian/Dockerfile
+++ b/v1.0/russian/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    ru.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/ru/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/spanish/Dockerfile
+++ b/v1.0/spanish/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    es.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/es/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/swedish/Dockerfile
+++ b/v1.0/swedish/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    sv.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/sv/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh

--- a/v1.0/turkish/Dockerfile
+++ b/v1.0/turkish/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre-alpine
 
 MAINTAINER  DBpedia Spotlight Team <dbp-spotlight-developers@lists.sourceforge.net>
 
@@ -6,12 +6,14 @@ ENV RELEASE_SERVER    downloads.dbpedia-spotlight.org
 ENV RELEASE_FILENAME  dbpedia-spotlight-1.0.0.jar 
 ENV LANGUAGE_MODEL    tr.tar.gz
 
-RUN mkdir -p /opt/spotlight && \
+RUN apk add --no-cache curl && \
+    mkdir -p /opt/spotlight && \
     cd /opt/spotlight && \
     curl -O "http://$RELEASE_SERVER/spotlight/$RELEASE_FILENAME" && \
     curl -O "http://$RELEASE_SERVER/2016-04/tr/model/$LANGUAGE_MODEL" && \
     tar xvf $LANGUAGE_MODEL  && \
-    rm  $LANGUAGE_MODEL
+    rm  $LANGUAGE_MODEL && \
+    apk del curl
 
 
 ADD spotlight.sh /bin/spotlight.sh


### PR DESCRIPTION
* The java base image is [deprecated](https://hub.docker.com/_/java/).
* This reduces image sizes. E.g. v1.0/Dutch went from 1.04 GB to 815 MB.